### PR TITLE
Configure TypeDoc to exclude externals

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -9,5 +9,6 @@
   "out": "./docs/build",
   "readme": "./README.md",
   "headings": { "readme": false },
-  "customCss": "./docs/custom.css"
+  "customCss": "./docs/custom.css",
+  "excludeExternals": true
 }


### PR DESCRIPTION
The documentation for exported interfaces that inherit/extend other types are expanded in an unhelpful way. This means that custom properties become mixed with a long list of inherited properties making the documentation hard to read (e.g. MakeCodeFrameProps). This hides externally resolved TypeScript files ([doc](https://typedoc.org/documents/Options.Input.html#excludeexternals)).