### PR TITLE
[DO NOT MERGE] Add story for MakeCode Editor without lang control

### DIFF
--- a/src/react/MakeCodeFrame.tsx
+++ b/src/react/MakeCodeFrame.tsx
@@ -34,6 +34,7 @@ export interface MakeCodeFrameProps
   version?: string;
   lang?: string;
   controller?: 1 | 2;
+  hideLanguage?: boolean;
   // You can use these to specify query variants or other options not directly supported by this component
   // https://github.com/microsoft/pxt-microbit/blob/master/pxtarget.json#L605C6-L605C14
   queryParams?: Record<string, string>;
@@ -72,6 +73,7 @@ const MakeCodeFrame = forwardRef<MakeCodeFrameDriver, MakeCodeFrameProps>(
       version,
       lang,
       controller,
+      hideLanguage,
       queryParams,
 
       initialProjects,
@@ -136,6 +138,7 @@ const MakeCodeFrame = forwardRef<MakeCodeFrameDriver, MakeCodeFrameProps>(
       version,
       lang,
       controller,
+      hideLanguage,
       queryParams
     );
     return (

--- a/src/stories/react/MakeCodeFrame.stories.tsx
+++ b/src/stories/react/MakeCodeFrame.stories.tsx
@@ -82,6 +82,24 @@ export const MakeCodeEditorWithControlsStory: Story = {
   },
 };
 
+export const MakeCodeEditorWithoutLangPickerStory: Story = {
+  name: 'MakeCode Editor without language picker',
+  args: {
+    version: 'default',
+  },
+  render: (args) => {
+    const { version } = args;
+    return (
+      <StoryWrapper>
+        <MakeCodeEditorWithControls
+          version={version === 'default' ? undefined : version}
+          hideLanguage
+        />
+      </StoryWrapper>
+    );
+  },
+};
+
 export const MakeCodeEditorControllerAppModeStory: Story = {
   name: 'MakeCode Editor with controller=2 mode',
   args: {

--- a/src/stories/vanilla/makecode-frame-driver.stories.tsx
+++ b/src/stories/vanilla/makecode-frame-driver.stories.tsx
@@ -15,6 +15,7 @@ interface StoryArgs {
     version?: string;
     lang?: string;
     controller?: 1 | 2;
+    hideLanguage?: boolean;
     queryParams?: Record<string, string>;
   };
   project?: MakeCodeProject;
@@ -44,6 +45,7 @@ const renderEditor = (args: StoryArgs) => {
       args.options?.version === 'default' ? undefined : args.options?.version,
       args.options?.lang,
       args.options?.controller ?? 1,
+      args.options?.hideLanguage,
       args.options?.queryParams
     );
     iframe.width = '100%';
@@ -88,6 +90,15 @@ export const MakeCodeEditorWithControlsStory: Story = {
   render: renderEditor,
   args: {
     options: { version: 'default', queryParams: { hideMenu: '' } },
+    project: defaultMakeCodeProject,
+  },
+};
+
+export const MakeCodeEditorWithoutLangPickerStory: Story = {
+  name: 'MakeCode Editor without language picker',
+  render: renderEditor,
+  args: {
+    options: { version: 'default', hideLanguage: true },
     project: defaultMakeCodeProject,
   },
 };

--- a/src/vanilla/makecode-frame-driver.ts
+++ b/src/vanilla/makecode-frame-driver.ts
@@ -819,7 +819,7 @@ export const createMakeCodeURL = (
     url.searchParams.set('controller', controller.toString());
   }
   if (hideLanguage) {
-    url.searchParams.set('hideLanguage', '1')
+    url.searchParams.set('hidelanguage', '1')
   }
   if (queryParams) {
     for (const [k, v] of Object.entries(queryParams)) {

--- a/src/vanilla/makecode-frame-driver.ts
+++ b/src/vanilla/makecode-frame-driver.ts
@@ -806,6 +806,7 @@ export const createMakeCodeURL = (
   version: string | undefined,
   lang: string | undefined,
   controller: number | undefined,
+  hideLanguage: boolean | undefined,
   queryParams: Record<string, string> | undefined
 ): string => {
   const url = new URL(
@@ -816,6 +817,9 @@ export const createMakeCodeURL = (
   }
   if (controller) {
     url.searchParams.set('controller', controller.toString());
+  }
+  if (hideLanguage) {
+    url.searchParams.set('hideLanguage', '1')
   }
   if (queryParams) {
     for (const [k, v] of Object.entries(queryParams)) {


### PR DESCRIPTION
[Task](https://microbit-global.monday.com/boards/1125389526/pulses/1999063946) (Private)

Add option to hide language picker in MakeCode embed by adding `?hidelanguage=1` query string param.

<img width="962" alt="Screenshot 2025-06-11 at 16 12 35" src="https://github.com/user-attachments/assets/9e3e10c7-078a-412f-b178-5cd14647d163" />
