### PR TITLE
Fix the unwanted initial navigation in MakeCode

### DIFF
--- a/src/vanilla/makecode-frame-driver.ts
+++ b/src/vanilla/makecode-frame-driver.ts
@@ -836,5 +836,7 @@ export const createMakeCodeURL = (
       url.searchParams.set(k, v);
     }
   }
+  // This avoids a navigation which will pollute the history of the embedding page.
+  url.hash = 'editor';
   return url.toString();
 };


### PR DESCRIPTION
If you open just the story iframe on its own from storybook (in a new tab so as to have no history) you can see that window.history.length after load drops from 2 (without fix) to 1 (this branch).

E.g. open https://ad0a07ba.makecode-embed.pages.dev/iframe?viewMode=story&id=stories-react-makecodeframe--make-code-editor-with-controls-story&args=

Motivated by https://github.com/microbit-foundation/ml-trainer/issues/562 and more especially by trying to get good Android app back behaviour.