### PR TITLE
Drop engine restrictions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,6 @@
         "typedoc": "^0.27.6",
         "typescript": "^5.2.2"
       },
-      "engines": {
-        "node": ">=24.0.0",
-        "npm": ">=11.18.0"
-      },
       "peerDependencies": {
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2"

--- a/package.json
+++ b/package.json
@@ -16,10 +16,6 @@
     "fsevents": true
   },
   "packageManager": "npm@11.18.0",
-  "engines": {
-    "node": ">=24.0.0",
-    "npm": ">=11.18.0"
-  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "typings": "./dist/esm/index.d.ts",


### PR DESCRIPTION
The node and npm restrictions were intended for library developers, not for consuming apps. 

We explored using `devEngines` to restrict engines for developers instead, but an attempt in a different library resulted in the [CI workflow failing](https://github.com/microbit-foundation/microbit-connection/actions/runs/29577977358/job/87876713920). The setup-node step threw a EBADDEVENGINES error (npm version is 11.16 instead of 11.18). The installation of 11.8 should happen after that, but it never reaches there. Instead, we will rely on the consuming apps to ensure we are using the correct engine versions.