### PR TITLE
Trusted publishing cfg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,5 +31,3 @@ jobs:
           path: ./storybook-static
       - run: npm publish --allow-directory=all
         if: github.event_name == 'release' && github.event.action == 'created'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- [ ] [Configure trusted publisher in GitHub Actions](https://docs.npmjs.com/trusted-publishers#for-github-actions)